### PR TITLE
Update Event.java

### DIFF
--- a/src/main/java/io/kestra/plugin/airbyte/models/Event.java
+++ b/src/main/java/io/kestra/plugin/airbyte/models/Event.java
@@ -6,6 +6,7 @@ import lombok.extern.jackson.Jacksonized;
 
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Value
 @Jacksonized
 @SuperBuilder

--- a/src/main/java/io/kestra/plugin/airbyte/models/Event.java
+++ b/src/main/java/io/kestra/plugin/airbyte/models/Event.java
@@ -1,10 +1,12 @@
 package io.kestra.plugin.airbyte.models;
 
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Value;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
-
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Value

--- a/src/test/java/io/kestra/plugin/airbyte/models/EventTest.java
+++ b/src/test/java/io/kestra/plugin/airbyte/models/EventTest.java
@@ -1,0 +1,41 @@
+package io.kestra.plugin.airbyte.models;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.junit.annotations.KestraTest;
+
+@KestraTest
+class EventTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserializeWithUnknownProperties() throws Exception {
+        String json = """
+            {
+                "timestamp": 1234567890,
+                "message": "Test message",
+                "level": "INFO",
+                "logSource": "test-source",
+                "caller": {"class": "TestClass", "method": "testMethod"},
+                "stackTrace": ["line1", "line2", "line3"],
+                "someOtherUnknownField": "value"
+            }
+            """;
+
+        Event event = objectMapper.readValue(json, Event.class);
+
+        assertThat(event, is(notNullValue()));
+        assertThat(event.getTimestamp(), is(1234567890L));
+        assertThat(event.getMessage(), is("Test message"));
+        assertThat(event.getLevel(), is("INFO"));
+        assertThat(event.getLogSource(), is("test-source"));
+        assertThat(event.getCaller(), is(notNullValue()));
+        assertThat(event.getCaller().get("class"), is("TestClass"));
+        assertThat(event.getCaller().get("method"), is("testMethod"));
+    }
+}


### PR DESCRIPTION
Closes https://github.com/kestra-io/plugin-airbyte/issues/113.

Handle unknown attributes on Event related to: 
https://github.com/kestra-io/plugin-airbyte/issues/113

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "stackTrace" (class io.kestra.plugin.airbyte.models.Event$EventBuilderImpl), not marked as ignorable (5 known properties: "caller", "level", "timestamp", "message", "logSource"])

 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2238574] (through reference chain: io.kestra.plugin.airbyte.models.JobInfo$JobInfoBuilderImpl["attempts"]->java.util.ArrayList[0]-
>io.kestra.plugin.airbyte.models.AttemptInfo$AttemptInfoBuilderImpl["logs"]-
>io.kestra.plugin.airbyte.models.Log$LogBuilderImpl["events"]->java.util.ArrayList[5271]-
>io.kestra.plugin.airbyte.models.Event$EventBuilderImpl["stackTrace"])
```