### PR TITLE
fix(test): catch SyncAlreadyRunningException

### DIFF
--- a/src/main/java/io/kestra/plugin/airbyte/connections/Sync.java
+++ b/src/main/java/io/kestra/plugin/airbyte/connections/Sync.java
@@ -125,7 +125,7 @@ public class Sync extends AbstractAirbyteConnection implements RunnableTask<Sync
                     .build());
 
             syncResponse = this.request(runContext, syncRequest, JobInfo.class);
-        } catch (HttpClientRequestException | HttpClientResponseException | RuntimeException e) {
+        } catch (HttpClientRequestException | HttpClientResponseException | SyncAlreadyRunningException | RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().contains("A sync is already running")) {
                 if (runContext.render(this.failOnActiveSync).as(Boolean.class).orElseThrow()) {
                     throw e;


### PR DESCRIPTION
- part-of: https://github.com/kestra-io/kestra-ee/issues/5013
- related-to: https://github.com/kestra-io/plugin-airbyte/pull/117