### PR TITLE
fix: retry transient HTTP failures on OSS and cloud connections

### DIFF
--- a/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
+++ b/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
@@ -70,7 +70,7 @@ public abstract class AbstractAirbyteConnection extends Task {
         description = "Deprecated – use `options` to configure timeouts. This field has no effect."
     )
     @Builder.Default
-    @PluginProperty(group = "execution")
+    @PluginProperty(group = "deprecated")
     private Property<Duration> httpTimeout = Property.ofValue(Duration.ofSeconds(10));
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
+++ b/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.airbyte;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -18,7 +19,9 @@ import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
+import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.RetryUtils;
 import io.kestra.plugin.airbyte.connections.SyncAlreadyRunningException;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -61,9 +64,10 @@ public abstract class AbstractAirbyteConnection extends Task {
     @PluginProperty(secret = true, group = "connection")
     private Property<String> token;
 
+    @Deprecated
     @Schema(
         title = "HTTP timeout",
-        description = "HTTP timeout value for requests to Airbyte. Defaults to 10 seconds"
+        description = "Deprecated – use `options` to configure timeouts. This field has no effect."
     )
     @Builder.Default
     @PluginProperty(group = "execution")
@@ -95,7 +99,7 @@ public abstract class AbstractAirbyteConnection extends Task {
         }
 
         if (this.username != null && this.password != null) {
-            String basicAuthValue = "Basic " + java.util.Base64.getEncoder().encodeToString(
+            var basicAuthValue = "Basic " + java.util.Base64.getEncoder().encodeToString(
                 (runContext.render(this.username).as(String.class).orElseThrow() + ":" +
                     runContext.render(this.password).as(String.class).orElseThrow()).getBytes()
             );
@@ -104,16 +108,65 @@ public abstract class AbstractAirbyteConnection extends Task {
 
         var request = requestBuilder.build();
 
-        try (HttpClient client = new HttpClient(runContext, options)) {
-            return client.request(request, responseType);
-        } catch (IOException e) {
+        try {
+            return this.<HttpResponse<RES>> buildRetry(runContext).runRetryIf(
+                this::isRetryableException,
+                () ->
+                {
+                    try (var client = new HttpClient(runContext, options)) {
+                        return client.request(request, responseType);
+                    } catch (HttpClientResponseException e) {
+                        if (this.isAlreadyRunningError(e)) {
+                            throw new AlreadyRunningWrapper();
+                        }
+                        throw e;
+                    }
+                }
+            );
+        } catch (AlreadyRunningWrapper e) {
+            throw new SyncAlreadyRunningException("A sync is already running");
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable e) {
             throw new RuntimeException("HTTP request failed", e);
-        } catch (HttpClientResponseException e) {
-            if (this.isAlreadyRunningError(e)) {
-                throw new SyncAlreadyRunningException("A sync is already running");
-            }
-            throw new RuntimeException("Request failed with status: " + e.getResponse().getStatus().getCode(), e);
         }
+    }
+
+    private static final class AlreadyRunningWrapper extends RuntimeException {
+        AlreadyRunningWrapper() {
+            super(null, null, true, false);
+        }
+    }
+
+    private boolean isRetryableException(Throwable t) {
+        if (t instanceof SyncAlreadyRunningException || t instanceof AlreadyRunningWrapper) {
+            return false;
+        }
+        if (t instanceof SocketTimeoutException) {
+            return true;
+        }
+        if (t instanceof HttpClientResponseException e) {
+            var code = e.getResponse().getStatus().getCode();
+            return code == 408 || code == 425 || code == 429 || (code >= 500 && code != 501);
+        }
+        if (t instanceof IOException) {
+            return !(t instanceof HttpClientResponseException) &&
+                (t.getCause() instanceof SocketTimeoutException || !(t instanceof HttpClientException));
+        }
+        return false;
+    }
+
+    private <T> RetryUtils.Instance<T, Exception> buildRetry(RunContext runContext) {
+        return RetryUtils.of(
+            Exponential.builder()
+                .delayFactor(2.0)
+                .interval(Duration.ofSeconds(1))
+                .maxInterval(Duration.ofSeconds(15))
+                .maxAttempts(-1)
+                .maxDuration(Duration.ofMinutes(5))
+                .build(),
+            runContext.logger()
+        );
     }
 
     private boolean isAlreadyRunningError(HttpClientResponseException exception) {
@@ -136,11 +189,11 @@ public abstract class AbstractAirbyteConnection extends Task {
 
     private void retrieveApplicationCredentialsToken(RunContext runContext) throws IllegalVariableEvaluationException {
         if (applicationCredentials != null) {
-            final String clientId = runContext.render(this.applicationCredentials.getClientId()).as(String.class).orElseThrow();
-            final String clientSecret = runContext.render(this.applicationCredentials.getClientSecret()).as(String.class).orElseThrow();
+            final var clientId = runContext.render(this.applicationCredentials.getClientId()).as(String.class).orElseThrow();
+            final var clientSecret = runContext.render(this.applicationCredentials.getClientSecret()).as(String.class).orElseThrow();
 
-            HttpRequest.HttpRequestBuilder applicationTokenRequestBuilder = HttpRequest.builder()
-                .uri(URI.create(getUrl() + "/api/v1/applications/token"))
+            var applicationTokenRequestBuilder = HttpRequest.builder()
+                .uri(URI.create(runContext.render(this.url).as(String.class).orElseThrow() + "/api/v1/applications/token"))
                 .method("POST")
                 .body(
                     HttpRequest.JsonRequestBody.builder()
@@ -156,12 +209,22 @@ public abstract class AbstractAirbyteConnection extends Task {
             applicationTokenRequestBuilder.addHeader("Accept", "application/json");
             applicationTokenRequestBuilder.addHeader("Content-Type", "application/json");
 
-            HttpRequest tokenRequest = applicationTokenRequestBuilder.build();
+            var tokenRequest = applicationTokenRequestBuilder.build();
 
             String applicationToken;
-            try (HttpClient client = new HttpClient(runContext, options)) {
-                applicationToken = (String) client.request(tokenRequest, Map.class).getBody().getOrDefault("access_token", null);
-            } catch (HttpClientException | IOException e) {
+            try {
+                applicationToken = this.<String> buildRetry(runContext).runRetryIf(
+                    this::isRetryableException,
+                    () ->
+                    {
+                        try (var client = new HttpClient(runContext, options)) {
+                            return (String) client.request(tokenRequest, Map.class).getBody().getOrDefault("access_token", null);
+                        }
+                    }
+                );
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Throwable e) {
                 throw new RuntimeException(e);
             }
 

--- a/src/main/java/io/kestra/plugin/airbyte/cloud/AbstractAirbyteCloud.java
+++ b/src/main/java/io/kestra/plugin/airbyte/cloud/AbstractAirbyteCloud.java
@@ -16,6 +16,7 @@ import com.airbyte.api.models.shared.SchemeClientCredentials;
 import com.airbyte.api.models.shared.Security;
 import com.airbyte.api.utils.SpeakeasyHTTPClient;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.retrys.Exponential;
@@ -25,7 +26,6 @@ import io.kestra.core.utils.RetryUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -127,7 +127,10 @@ public abstract class AbstractAirbyteCloud extends Task {
             try {
                 return retry
                     .run(
-                        (httpResponse) -> httpResponse.statusCode() == 408,
+                        (httpResponse) -> httpResponse.statusCode() == 408
+                            || httpResponse.statusCode() == 425
+                            || httpResponse.statusCode() == 429
+                            || (httpResponse.statusCode() >= 500 && httpResponse.statusCode() != 501),
                         () -> super.send(request)
                     );
             } catch (Exception e) {

--- a/src/test/java/io/kestra/plugin/airbyte/connections/SyncRetryTest.java
+++ b/src/test/java/io/kestra/plugin/airbyte/connections/SyncRetryTest.java
@@ -1,0 +1,126 @@
+package io.kestra.plugin.airbyte.connections;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+@WireMockTest(httpPort = 18081)
+class SyncRetryTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void retries_on_503_then_succeeds(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        stubFor(
+            post(urlPathEqualTo("/api/v1/applications/token"))
+                .willReturn(okJson("{\"access_token\":\"ey.mock.token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"))
+        );
+
+        stubFor(
+            post(urlPathMatching("/api/v1/connections/sync/?"))
+                .inScenario("retry-503")
+                .whenScenarioStateIs("Started")
+                .willReturn(serviceUnavailable())
+                .willSetStateTo("first-attempt-done")
+        );
+
+        stubFor(
+            post(urlPathMatching("/api/v1/connections/sync/?"))
+                .inScenario("retry-503")
+                .whenScenarioStateIs("first-attempt-done")
+                .willReturn(okJson("""
+                    {
+                      "job": { "id": 456, "status": "running" },
+                      "attempts": []
+                    }
+                    """))
+        );
+
+        stubFor(
+            post(urlPathMatching("/api/v1/jobs/get/?"))
+                .willReturn(okJson("""
+                    {
+                      "job": { "id": 456, "status": "succeeded" },
+                      "attempts": [
+                        {
+                          "attempt": { "id": 0, "status": "succeeded" },
+                          "logs": { "logLines": [] }
+                        }
+                      ]
+                    }
+                    """))
+        );
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var task = Sync.builder()
+            .url(Property.ofValue(wireMockRuntimeInfo.getHttpBaseUrl()))
+            .applicationCredentials(
+                io.kestra.plugin.airbyte.AbstractAirbyteConnection.ApplicationCredentials.builder()
+                    .clientId(Property.ofValue("client-id"))
+                    .clientSecret(Property.ofValue("client-secret"))
+                    .build()
+            )
+            .connectionId(Property.ofValue("conn-retry-test"))
+            .wait(Property.ofValue(true))
+            .build();
+
+        var out = task.run(runContext);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getJobId(), notNullValue());
+
+        verify(moreThanOrExactly(2), postRequestedFor(urlPathMatching("/api/v1/connections/sync/?")));
+    }
+
+    @Test
+    void does_not_retry_on_409(WireMockRuntimeInfo wireMockRuntimeInfo) {
+        stubFor(
+            post(urlPathEqualTo("/api/v1/applications/token"))
+                .willReturn(okJson("{\"access_token\":\"ey.mock.token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"))
+        );
+
+        stubFor(
+            post(urlPathMatching("/api/v1/connections/sync/?"))
+                .willReturn(aResponse().withStatus(409).withBody("""
+                    {
+                      "message": "A sync is already running for this connection"
+                    }
+                    """))
+        );
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var task = Sync.builder()
+            .url(Property.ofValue(wireMockRuntimeInfo.getHttpBaseUrl()))
+            .applicationCredentials(
+                io.kestra.plugin.airbyte.AbstractAirbyteConnection.ApplicationCredentials.builder()
+                    .clientId(Property.ofValue("client-id"))
+                    .clientSecret(Property.ofValue("client-secret"))
+                    .build()
+            )
+            .connectionId(Property.ofValue("conn-no-retry-409"))
+            .failOnActiveSync(Property.ofValue(true))
+            .wait(Property.ofValue(false))
+            .build();
+
+        assertThrows(SyncAlreadyRunningException.class, () -> task.run(runContext));
+
+        verify(exactly(1), postRequestedFor(urlPathMatching("/api/v1/connections/sync/?")));
+    }
+}


### PR DESCRIPTION
## Summary

- Add exponential backoff retry to `AbstractAirbyteConnection.request()` and `retrieveApplicationCredentialsToken()` for `SocketTimeoutException`, generic `IOException`, and retryable HTTP status codes (408, 425, 429, 5xx except 501)
- 409 / `SyncAlreadyRunningException` bypasses retry as terminal business state
- Extend cloud `CustomHttpClient` retry predicate from 408-only to also cover 425, 429, 5xx (except 501)
- Deprecate dead `httpTimeout` field (was never wired to `HttpClient` — `options` is the correct way to configure timeouts)
- Fix URI construction bug in `retrieveApplicationCredentialsToken` (was using unrendered `Property<String>` directly in `URI.create()`)

## Test plan

- [ ] `./gradlew check` passes
- [ ] `SyncRetryTest.retries_on_503_then_succeeds` — WireMock 503→200, verifies ≥2 calls and task succeeds
- [ ] `SyncRetryTest.does_not_retry_on_409` — WireMock 409, verifies exactly 1 call and `SyncAlreadyRunningException` thrown

Fixes #144