### PR TITLE
fix: retry RuntimeException-wrapped SocketTimeoutException in OSS connections

### DIFF
--- a/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
+++ b/src/main/java/io/kestra/plugin/airbyte/AbstractAirbyteConnection.java
@@ -153,6 +153,10 @@ public abstract class AbstractAirbyteConnection extends Task {
             return !(t instanceof HttpClientResponseException) &&
                 (t.getCause() instanceof SocketTimeoutException || !(t instanceof HttpClientException));
         }
+        // HttpClient wraps low-level exceptions (e.g. SocketTimeoutException) in RuntimeException
+        if (t.getCause() != null) {
+            return isRetryableException(t.getCause());
+        }
         return false;
     }
 


### PR DESCRIPTION
## Summary

- `HttpClient.request()` wraps low-level `SocketTimeoutException` in a plain `RuntimeException` before propagating to our retry predicate
- `isRetryableException` only matched direct `SocketTimeoutException` / `IOException` subtypes — a wrapped `RuntimeException` fell through to `return false`, silently skipping retry
- Added cause-chain recursion so any wrapped retryable exception is correctly identified and retried with exponential backoff

## Root cause (from customer logs)

```
java.lang.RuntimeException: java.net.SocketTimeoutException: Read timed out
    at io.kestra.core.http.client.HttpClient.request(HttpClient.java:533)
```

The predicate received a `RuntimeException`, not a `SocketTimeoutException`, so none of the `instanceof` checks matched.

## Test plan

- [ ] Existing `SyncRetryTest` passes (503 retry + 409 no-retry)
- [ ] Manually verify retry fires on a read-timeout scenario

Reported by jack@foundationdata.com — Pylon issue [#1737](https://app.usepylon.com/support/issues/views/36469f3c-64a7-47dc-8e82-9d36026bfc31?issueNumber=1737&view=fs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)