### PR TITLE
fix(plugin-airbyte): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/airbyte/cloud/jobs/package-info.java
+++ b/src/main/java/io/kestra/plugin/airbyte/cloud/jobs/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Airbyte Cloud Jobs",
     description = "This sub-group of plugins contains tasks for using Airbyte Cloud Jobs.\n" +
         "Airbyte is an open-source data integration engine that helps you consolidate your data in your data warehouses, data lakes and databases.",
     categories = {

--- a/src/main/java/io/kestra/plugin/airbyte/connections/package-info.java
+++ b/src/main/java/io/kestra/plugin/airbyte/connections/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Airbyte Connections",
     description = "This sub-group of plugins contains tasks for using Airbyte.\n" +
         "Airbyte is an open-source data integration engine that helps you consolidate your data in your data warehouses, lakes and databases.",
     categories = {


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge